### PR TITLE
feat(acme): Tier 2 shortlived cadence ramp + cert renewal failure counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,41 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **Tier 2 ACME cert renewal ramped to LE shortlived cadence (6-day certs).**
+  The auto-healer now calls `POST /ssl/agent/renew` on the local agent when
+  `servers.agent_acme_cert_expiry` is within 3 days (50% of the 6-day
+  shortlived lifetime). The agent provisions a fresh cert via `instant_acme`
+  with `profile = "shortlived"`, writes it to
+  `/etc/dockpanel/ssl/agent-acme.{crt,key}`, and returns the new SHA-256
+  fingerprint so the backend can atomically update `servers.cert_fingerprint`
+  without waiting for the next agent checkin cycle.
+  Two new DB columns (`agent_acme_cert_domain`, `agent_acme_cert_expiry`) on
+  the `servers` table track per-server ACME cert state
+  (`migrations/20260514000000_cert_renewal_failures.sql`). Tier 2 ACME is
+  opt-in: the self-signed rcgen fallback continues to work for servers that
+  do not set `agent_acme_cert_domain`. Live TLS reload deferred — see the
+  PR's Questions for review section.
+
+- **Prometheus counter `dockpanel_cert_renewal_failures_total{cert_kind,reason}`.**
+  Incremented by the auto-healer on every failed ACME renewal attempt.
+  `cert_kind` ∈ `{agent_pinned, panel_public, site}`;
+  `reason` ∈ `{acme_error, dns_check, rate_limit, network, other}`.
+  Counts persist across backend restarts in the new `cert_renewal_failures`
+  DB table and are scraped by the fleet Prometheus exporter at
+  `/api/metrics`. All 15 label combinations are pre-populated at migration
+  time so the metric is always present (with value 0) before any failure
+  occurs.
+
+### Changed
+
+- **Shortlived ACME cert fallback renewal margin corrected from 2 days to 3 days.**
+  The `fallback_renewal_margin("shortlived")` in `auto_healer.rs` now returns
+  `Duration::days(3)` (50% of the 6-day cert lifetime, per LE's shortlived
+  guidance), up from the previous 2 days (≈ 33%). This applies to site certs
+  using `ssl_profile = 'shortlived'` when ARI is unavailable.
+
 ## [2.8.19] - 2026-05-10
 
 ### Fixed

--- a/panel/agent/src/routes/ssl.rs
+++ b/panel/agent/src/routes/ssl.rs
@@ -330,6 +330,82 @@ async fn renew(
     })))
 }
 
+// ── Tier 2 ACME agent cert ───────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct AgentRenewRequest {
+    email: String,
+    domain: String,
+}
+
+/// POST /ssl/agent/renew — Renew the agent's own TLS cert via ACME (shortlived, 6-day).
+///
+/// Called by the backend's auto-healer when `servers.agent_acme_cert_expiry`
+/// is within 3 days (50% of the shortlived lifetime). The response includes
+/// the new cert's SHA-256 fingerprint so the backend can update the TOFU pin
+/// in `servers.cert_fingerprint` without waiting for the next agent checkin.
+///
+/// Note: the renewed cert is written to disk. Live TLS reload is not
+/// performed in this PR — see PR body § Questions for review.
+async fn renew_agent_cert(
+    Json(body): Json<AgentRenewRequest>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let cert_info = ssl::provision_agent_acme_cert(&body.email, &body.domain)
+        .await
+        .map_err(|e| {
+            tracing::error!("Tier 2 ACME agent cert renewal failed for {}: {e}", body.domain);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": e })),
+            )
+        })?;
+
+    // Read the freshly written cert and compute its fingerprint so the
+    // backend can update cert_fingerprint in one round-trip.
+    let cert_pem = tokio::fs::read(ssl::AGENT_ACME_CERT_PATH).await.map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": format!("read agent cert: {e}") })),
+        )
+    })?;
+    let fingerprint = ssl::fingerprint_from_pem(&cert_pem).map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": e })),
+        )
+    })?;
+
+    tracing::info!(
+        "Tier 2 ACME agent cert renewed for {} — new fingerprint: {}",
+        body.domain,
+        &fingerprint[..8]
+    );
+
+    Ok(Json(serde_json::json!({
+        "ok": true,
+        "domain": body.domain,
+        "expiry": cert_info.expiry,
+        "fingerprint": fingerprint,
+        "cert_path": cert_info.cert_path,
+        "key_path": cert_info.key_path,
+        "profile": cert_info.profile,
+    })))
+}
+
+/// GET /ssl/agent/status — Return presence and fingerprint of the Tier 2 ACME agent cert.
+async fn agent_cert_status() -> Json<serde_json::Value> {
+    let cert_path = ssl::AGENT_ACME_CERT_PATH;
+    if !std::path::Path::new(cert_path).exists() {
+        return Json(serde_json::json!({ "has_acme_cert": false }));
+    }
+    let pem = tokio::fs::read(cert_path).await.ok();
+    let fingerprint = pem.as_deref().and_then(|b| ssl::fingerprint_from_pem(b).ok());
+    Json(serde_json::json!({
+        "has_acme_cert": true,
+        "fingerprint": fingerprint,
+    }))
+}
+
 /// GET /ssl/profiles — List ACME profiles advertised by the CA.
 async fn profiles(
     axum::extract::Query(q): axum::extract::Query<ProfilesQuery>,
@@ -518,6 +594,11 @@ async fn provision_dns01(
 
 pub fn router() -> Router<AppState> {
     Router::new()
+        // Tier 2 ACME agent cert routes (registered before /{domain} patterns
+        // so the literal "agent" segment is not captured as a domain parameter).
+        .route("/ssl/agent/renew", post(renew_agent_cert))
+        .route("/ssl/agent/status", get(agent_cert_status))
+        // Site cert routes
         .route("/ssl/provision/{domain}", post(provision))
         .route("/ssl/provision-dns01/{domain}", post(provision_dns01))
         .route("/ssl/status/{domain}", get(status))

--- a/panel/agent/src/services/ssl.rs
+++ b/panel/agent/src/services/ssl.rs
@@ -13,6 +13,12 @@ const ACME_ACCOUNT_PATH: &str = "/etc/dockpanel/ssl/acme-account.json";
 const SSL_DIR: &str = "/etc/dockpanel/ssl";
 const ACME_WEBROOT: &str = "/var/www/acme";
 
+/// On-disk paths for the Tier 2 ACME-issued agent TLS cert.
+/// Separate from the self-signed fallback cert in tls.rs so both can coexist
+/// during a gradual rollout (ACME cert is preferred when present).
+pub const AGENT_ACME_CERT_PATH: &str = "/etc/dockpanel/ssl/agent-acme.crt";
+pub const AGENT_ACME_KEY_PATH: &str = "/etc/dockpanel/ssl/agent-acme.key";
+
 /// Options controlling an ACME order — profile selection + ARI replacement chain.
 /// `None` or all-None fields means "classic, no prior cert" (backwards-compatible).
 #[derive(Default, Clone)]
@@ -570,6 +576,65 @@ pub async fn enable_ssl_for_site(
 
     tracing::info!("Nginx updated with SSL for {domain}");
     Ok(())
+}
+
+// ── Tier 2 ACME agent cert ───────────────────────────────────────────────
+
+/// Provision (or renew) the agent's own TLS certificate via ACME using the
+/// `shortlived` profile (6-day validity, LE flip live 2026-05-13).
+///
+/// The cert is written to `AGENT_ACME_CERT_PATH` / `AGENT_ACME_KEY_PATH`.
+/// The domain must be publicly HTTP-01 resolvable. Live TLS reload is out of
+/// scope for this PR — see PR body § Questions for review.
+pub async fn provision_agent_acme_cert(email: &str, domain: &str) -> Result<CertInfo, String> {
+    let account = load_or_create_account(email).await?;
+
+    let replaces_pem = tokio::fs::read_to_string(AGENT_ACME_CERT_PATH).await.ok();
+
+    let opts = ProvisionOpts {
+        profile: Some("shortlived"),
+        replaces_pem: replaces_pem.as_deref(),
+    };
+
+    // Provision via HTTP-01 (same path as site certs, different target domain).
+    let cert_info = provision_cert(&account, domain, Some(&opts)).await?;
+
+    // Copy into the stable agent-acme paths so the agent can be configured
+    // to prefer this cert over the rcgen self-signed fallback.
+    tokio::fs::copy(&cert_info.cert_path, AGENT_ACME_CERT_PATH)
+        .await
+        .map_err(|e| format!("copy cert to {AGENT_ACME_CERT_PATH}: {e}"))?;
+    tokio::fs::copy(&cert_info.key_path, AGENT_ACME_KEY_PATH)
+        .await
+        .map_err(|e| format!("copy key to {AGENT_ACME_KEY_PATH}: {e}"))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = tokio::fs::set_permissions(
+            AGENT_ACME_KEY_PATH,
+            std::fs::Permissions::from_mode(0o600),
+        )
+        .await;
+    }
+
+    tracing::info!("Tier 2 ACME agent cert (shortlived) provisioned for {domain}");
+
+    Ok(CertInfo {
+        cert_path: AGENT_ACME_CERT_PATH.to_string(),
+        key_path: AGENT_ACME_KEY_PATH.to_string(),
+        expiry: cert_info.expiry,
+        profile: Some("shortlived".to_string()),
+    })
+}
+
+/// SHA-256 fingerprint of the first certificate in a PEM blob (lowercase hex).
+/// Used by the `/ssl/agent/renew` route to return the new pin to the backend
+/// so it can update `servers.cert_fingerprint` without a separate checkin round-trip.
+pub fn fingerprint_from_pem(pem: &[u8]) -> Result<String, String> {
+    use sha2::Digest;
+    let der = first_cert_der(pem).ok_or_else(|| "no certificate found in PEM".to_string())?;
+    Ok(hex::encode(sha2::Sha256::digest(&der)))
 }
 
 // ── ACME profile + ARI (RFC 9773) helpers ────────────────────────────────

--- a/panel/backend/migrations/20260514000000_cert_renewal_failures.sql
+++ b/panel/backend/migrations/20260514000000_cert_renewal_failures.sql
@@ -1,0 +1,27 @@
+-- Tier 2 ACME cert tracking columns on each server row.
+-- agent_acme_cert_domain: the domain used for the ACME order (must resolve via HTTP-01).
+-- agent_acme_cert_expiry: expiry of the current ACME-issued agent TLS cert.
+--   Renewal is triggered when expiry < NOW() + 3 days (50% of the 6-day shortlived lifetime).
+ALTER TABLE servers
+    ADD COLUMN IF NOT EXISTS agent_acme_cert_domain TEXT,
+    ADD COLUMN IF NOT EXISTS agent_acme_cert_expiry  TIMESTAMPTZ;
+
+-- Running counters for ACME cert renewal failures.
+-- The Prom exporter renders these as dockpanel_cert_renewal_failures_total{cert_kind,reason}.
+-- Using a DB table so counts survive backend restarts (unlike in-memory atomics).
+CREATE TABLE IF NOT EXISTS cert_renewal_failures (
+    cert_kind TEXT    NOT NULL,
+    reason    TEXT    NOT NULL,
+    count     BIGINT  NOT NULL DEFAULT 0,
+    PRIMARY KEY (cert_kind, reason)
+);
+
+-- Pre-populate every (cert_kind × reason) combination so the metric is
+-- always present in Prometheus scrapes even before any failure occurs.
+-- ON CONFLICT DO NOTHING preserves counts on re-runs (e.g. migration re-apply).
+INSERT INTO cert_renewal_failures (cert_kind, reason, count)
+SELECT c.kind, r.reason, 0
+FROM   (VALUES ('agent_pinned'), ('panel_public'), ('site')) AS c(kind)
+CROSS JOIN
+       (VALUES ('acme_error'), ('dns_check'), ('rate_limit'), ('network'), ('other')) AS r(reason)
+ON CONFLICT DO NOTHING;

--- a/panel/backend/src/services/auto_healer.rs
+++ b/panel/backend/src/services/auto_healer.rs
@@ -50,6 +50,7 @@ pub async fn run(pool: PgPool, agent: AgentClient, mut shutdown_rx: tokio::sync:
         auto_restart_services(&pool, &agent).await;
         auto_clean_disk(&pool, &agent).await;
         auto_renew_ssl(&pool, &agent).await;
+        auto_renew_agent_certs(&pool, &agent).await;
         auto_sleep_idle_containers(&pool, &agent).await;
 
         // Security hardening tasks (run every 2 minutes with auto-healer)
@@ -677,6 +678,8 @@ async fn auto_renew_ssl(pool: &PgPool, agent: &AgentClient) {
             )
             .await;
 
+            record_renewal_failure(pool, "site", classify_renewal_error(&details)).await;
+
             crate::services::system_log::log_event(
                 pool,
                 "error",
@@ -693,16 +696,227 @@ async fn auto_renew_ssl(pool: &PgPool, agent: &AgentClient) {
 /// Fallback renewal margin when the CA doesn't advertise ARI. Maps profile
 /// → days-remaining threshold at which we trigger renewal.
 ///
-/// - `shortlived` (~6d): renew at 2d remaining (≈ 2/3 consumed, matches LE's
-///   "renew every 2-3 days" guidance).
+/// - `shortlived` (6d LE shortlived profile, live 2026-05-13): renew at 3d
+///   remaining — exactly 50% of the cert lifetime, matching LE's guidance
+///   for the shortlived cadence. (Was 2d prior to the 2026-05-13 flip;
+///   bumped to 3d to hit the 50% mark.)
 /// - `tlsserver` (45d from 2026-05-13 onward): renew at 15d remaining (1/3).
 /// - `classic` or unknown (90d today, 64d in 2027, 45d in 2028): renew at
 ///   30d remaining, which is safe across all three horizons.
 fn fallback_renewal_margin(profile: Option<&str>) -> chrono::Duration {
     match profile {
-        Some("shortlived") => chrono::Duration::days(2),
+        Some("shortlived") => chrono::Duration::days(3),
         Some("tlsserver") => chrono::Duration::days(15),
         _ => chrono::Duration::days(30),
+    }
+}
+
+// ── Cert-renewal failure counter helpers ────────────────────────────────
+
+/// Map a renewal error string to a Prometheus `reason` label value.
+/// Must stay in sync with the label cardinality defined in
+/// `migrations/20260514000000_cert_renewal_failures.sql`.
+fn classify_renewal_error(err: &str) -> &'static str {
+    let e = err.to_ascii_lowercase();
+    if e.contains("rate limit") || e.contains("ratelimited") || e.contains("too many") {
+        "rate_limit"
+    } else if e.contains("dns") || e.contains("nxdomain") || e.contains("resolve") || e.contains("lookup") {
+        "dns_check"
+    } else if e.contains("connection") || e.contains("connect") || e.contains("timeout") || e.contains("network") {
+        "network"
+    } else if e.contains("acme") || e.contains("challenge") || e.contains("order") || e.contains("authorization") {
+        "acme_error"
+    } else {
+        "other"
+    }
+}
+
+/// Atomically increment the `cert_renewal_failures` counter for the given labels.
+/// Silently swallows DB errors — a missing counter row is better than a panic.
+async fn record_renewal_failure(pool: &PgPool, cert_kind: &str, reason: &str) {
+    let _ = sqlx::query(
+        "INSERT INTO cert_renewal_failures (cert_kind, reason, count) VALUES ($1, $2, 1) \
+         ON CONFLICT (cert_kind, reason) \
+         DO UPDATE SET count = cert_renewal_failures.count + 1",
+    )
+    .bind(cert_kind)
+    .bind(reason)
+    .execute(pool)
+    .await;
+}
+
+// ── Tier 2 ACME agent cert renewal ──────────────────────────────────────
+
+/// Auto-renew ACME-issued agent TLS certs (Tier 2 / shortlived profile).
+///
+/// Queries servers with `agent_acme_cert_domain IS NOT NULL` and calls
+/// `POST /ssl/agent/renew` on the local agent when the cert has ≤ 3 days
+/// remaining (50% of the 6-day shortlived validity).
+///
+/// Remote-agent cert renewal requires `AgentRegistry` access, which the
+/// auto_healer doesn't currently receive. See PR body § Questions for review.
+async fn auto_renew_agent_certs(pool: &PgPool, agent: &AgentClient) {
+    let servers: Vec<(
+        uuid::Uuid,
+        uuid::Uuid,
+        String,
+        Option<chrono::DateTime<chrono::Utc>>,
+    )> = match sqlx::query_as(
+        "SELECT id, user_id, agent_acme_cert_domain, agent_acme_cert_expiry \
+         FROM servers \
+         WHERE is_local = TRUE AND agent_acme_cert_domain IS NOT NULL",
+    )
+    .fetch_all(pool)
+    .await
+    {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+
+    let now = chrono::Utc::now();
+
+    for (server_id, user_id, domain, expiry) in &servers {
+        // Renew when ≤ 3 days remain (50% of 6-day shortlived lifetime).
+        let is_due = match expiry {
+            Some(exp) => (*exp - now).num_days() <= 3,
+            None => true, // No cert yet — provision now.
+        };
+        if !is_due {
+            continue;
+        }
+
+        // 3-hour cooldown between attempts (prevents CA hammering).
+        let recent: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM activity_logs \
+             WHERE action = 'auto_heal.renew_agent_cert' \
+             AND target_name = $1 \
+             AND created_at > NOW() - INTERVAL '3 hours'",
+        )
+        .bind(domain)
+        .fetch_one(pool)
+        .await
+        .unwrap_or((0,));
+        if recent.0 > 0 {
+            continue;
+        }
+
+        tracing::info!("Auto-heal: renewing Tier 2 ACME agent cert for {domain}");
+
+        let email: String = match sqlx::query_scalar("SELECT email FROM users WHERE id = $1")
+            .bind(user_id)
+            .fetch_optional(pool)
+            .await
+        {
+            Ok(Some(e)) => e,
+            _ => {
+                tracing::warn!(
+                    "Auto-heal: cannot renew agent cert for {domain} — owner email not found"
+                );
+                continue;
+            }
+        };
+
+        let result = agent
+            .post(
+                "/ssl/agent/renew",
+                Some(serde_json::json!({ "email": email, "domain": domain })),
+            )
+            .await;
+
+        let success = result.is_ok();
+        let details = match &result {
+            Ok(v) => v.to_string(),
+            Err(e) => e.to_string(),
+        };
+
+        let system_id = uuid::Uuid::nil();
+        activity::log_activity(
+            pool,
+            system_id,
+            "auto-healer",
+            "auto_heal.renew_agent_cert",
+            Some("server"),
+            Some(domain),
+            Some(&format!(
+                "server_id={server_id}, success={success}, result={details}"
+            )),
+            None,
+        )
+        .await;
+
+        if success {
+            if let Ok(ref resp) = result {
+                let new_expiry = resp
+                    .get("expiry")
+                    .and_then(|v| v.as_str())
+                    .and_then(|s| {
+                        chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S%.f UTC").ok()
+                    })
+                    .map(|dt| dt.and_utc());
+                let new_fp = resp.get("fingerprint").and_then(|v| v.as_str());
+
+                let _ = sqlx::query(
+                    "UPDATE servers \
+                     SET agent_acme_cert_expiry = $1, \
+                         cert_fingerprint = COALESCE($2, cert_fingerprint), \
+                         updated_at = NOW() \
+                     WHERE id = $3",
+                )
+                .bind(new_expiry)
+                .bind(new_fp)
+                .bind(server_id)
+                .execute(pool)
+                .await;
+            }
+            tracing::info!("Auto-heal: Tier 2 ACME agent cert renewed for {domain}");
+        } else {
+            record_renewal_failure(pool, "agent_pinned", classify_renewal_error(&details)).await;
+            crate::services::system_log::log_event(
+                pool,
+                "error",
+                "auto_healer",
+                &format!("Tier 2 ACME agent cert renewal failed for {domain}"),
+                Some(&details),
+            )
+            .await;
+            tracing::warn!(
+                "Auto-heal: agent cert renewal failed for {domain}: {details}"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::classify_renewal_error;
+
+    #[test]
+    fn classify_rate_limit() {
+        assert_eq!(classify_renewal_error("ACME rate limit exceeded"), "rate_limit");
+        assert_eq!(classify_renewal_error("too many certificates"), "rate_limit");
+    }
+
+    #[test]
+    fn classify_dns_check() {
+        assert_eq!(classify_renewal_error("DNS lookup failed for example.com"), "dns_check");
+        assert_eq!(classify_renewal_error("NXDOMAIN: no such host"), "dns_check");
+    }
+
+    #[test]
+    fn classify_network() {
+        assert_eq!(classify_renewal_error("connection refused"), "network");
+        assert_eq!(classify_renewal_error("request timed out"), "network");
+    }
+
+    #[test]
+    fn classify_acme_error() {
+        assert_eq!(classify_renewal_error("ACME challenge validation failed"), "acme_error");
+        assert_eq!(classify_renewal_error("order status: invalid"), "acme_error");
+    }
+
+    #[test]
+    fn classify_other() {
+        assert_eq!(classify_renewal_error("unexpected io error: permission denied"), "other");
     }
 }
 

--- a/panel/backend/src/services/prometheus_exporter.rs
+++ b/panel/backend/src/services/prometheus_exporter.rs
@@ -18,6 +18,7 @@ pub async fn render(pool: &PgPool) -> String {
     render_gpu(&mut out, pool).await;
     render_sites(&mut out, pool).await;
     render_alerts(&mut out, pool).await;
+    render_cert_renewal_failures(&mut out, pool).await;
 
     out
 }
@@ -159,6 +160,42 @@ async fn render_alerts(out: &mut String, pool: &PgPool) {
     }
 }
 
+// ── Cert renewal failure counter ────────────────────────────────────────
+
+/// Render `dockpanel_cert_renewal_failures_total` from pre-fetched rows.
+/// Extracted for testability — the async DB fetch is in `render_cert_renewal_failures`.
+fn render_cert_renewal_failures_rows(out: &mut String, rows: &[(String, String, i64)]) {
+    let _ = writeln!(
+        out,
+        "# HELP dockpanel_cert_renewal_failures_total ACME cert renewal failures by kind and reason."
+    );
+    let _ = writeln!(out, "# TYPE dockpanel_cert_renewal_failures_total counter");
+    for (cert_kind, reason, count) in rows {
+        let _ = write!(out, "dockpanel_cert_renewal_failures_total{{cert_kind=\"");
+        push_escaped(out, cert_kind);
+        let _ = write!(out, "\",reason=\"");
+        push_escaped(out, reason);
+        let _ = writeln!(out, "\"}} {count}");
+    }
+}
+
+async fn render_cert_renewal_failures(out: &mut String, pool: &PgPool) {
+    let rows: Vec<(String, String, i64)> = sqlx::query_as(
+        "SELECT cert_kind, reason, count \
+         FROM cert_renewal_failures \
+         ORDER BY cert_kind, reason",
+    )
+    .fetch_all(pool)
+    .await
+    .unwrap_or_default();
+
+    if rows.is_empty() {
+        return;
+    }
+
+    render_cert_renewal_failures_rows(out, &rows);
+}
+
 // ── Label-line writers ──────────────────────────────────────────────────
 
 fn write_server_sample(out: &mut String, metric: &str, sid: &uuid::Uuid, name: &str, v: f32) {
@@ -217,5 +254,43 @@ mod tests {
         let mut s = String::new();
         push_escaped(&mut s, "my-server-01");
         assert_eq!(s, "my-server-01");
+    }
+
+    /// Asserts that the cert-renewal failure counter renders correctly and that
+    /// incremented counts appear in the output — the core of the Tier 2 ACME
+    /// failure metric requirement.
+    #[test]
+    fn acme_renewal_failure_metric_increments() {
+        let rows = vec![
+            ("agent_pinned".to_string(), "acme_error".to_string(), 3i64),
+            ("agent_pinned".to_string(), "network".to_string(), 0i64),
+            ("site".to_string(), "network".to_string(), 1i64),
+            ("site".to_string(), "rate_limit".to_string(), 0i64),
+        ];
+        let mut out = String::new();
+        super::render_cert_renewal_failures_rows(&mut out, &rows);
+
+        assert!(
+            out.contains("# TYPE dockpanel_cert_renewal_failures_total counter"),
+            "missing TYPE line"
+        );
+        assert!(
+            out.contains(
+                "dockpanel_cert_renewal_failures_total{cert_kind=\"agent_pinned\",reason=\"acme_error\"} 3"
+            ),
+            "expected count 3 for agent_pinned/acme_error"
+        );
+        assert!(
+            out.contains(
+                "dockpanel_cert_renewal_failures_total{cert_kind=\"site\",reason=\"network\"} 1"
+            ),
+            "expected count 1 for site/network"
+        );
+        assert!(
+            out.contains(
+                "dockpanel_cert_renewal_failures_total{cert_kind=\"agent_pinned\",reason=\"network\"} 0"
+            ),
+            "expected zero-value row for agent_pinned/network"
+        );
     }
 }


### PR DESCRIPTION
## Why

Closes the v2.8.2 carryover for Tier 2 ACME. Locked behind LE's 2026-05-13 shortlived profile flip — pre-flight was attempted on 2026-05-14 but blocked by network sandbox (no outbound HTTP from the CI environment). Contextual confidence: today's date is 2026-05-14 (one day after the scheduled flip), the existing `ProvisionOpts` in `agent/src/services/ssl.rs` already references `"shortlived"` as a valid profile, and the code was previously wired to accept it. If the actual LE flip has not yet propagated, the first `auto_renew_agent_certs` cycle will surface an ACME error and increment `dockpanel_cert_renewal_failures_total{cert_kind="agent_pinned",reason="acme_error"}`, which will alert operators.

> **Note on pre-flight:** `acme-v02.api.letsencrypt.org` was unreachable from this session (network allowlist). The infra-leak pre-commit hook may flag `acme-v02.api.letsencrypt.org` in this PR body — that hostname is intentional (audit reference, not a secret) and does not need to be scrubbed.

---

## What

### (1) Tier 2 ACME cert renewal — shortlived cadence

The Tier 2 path issues certs for inter-server agent TLS (server-to-agent pinning via `RemoteAgentClient::PinnedFingerprintVerifier`).

**Agent side** (`panel/agent/src/services/ssl.rs`, `panel/agent/src/routes/ssl.rs`):
- `provision_agent_acme_cert(email, domain)` — issues/renews the agent's own TLS cert via `instant_acme` with `profile = "shortlived"` (6-day validity). Writes to `/etc/dockpanel/ssl/agent-acme.{crt,key}`. Passes the existing cert as the RFC 9773 ARI `replaces` hint for continuity.
- `fingerprint_from_pem(pem)` — SHA-256 of the cert DER (reuses `first_cert_der` already in the service).
- `POST /ssl/agent/renew` — called by the backend auto-healer. Returns `{ok, expiry, fingerprint, …}` so the panel can update `servers.cert_fingerprint` in one round-trip (no extra checkin needed).
- `GET /ssl/agent/status` — returns `{has_acme_cert, fingerprint}` for monitoring.

**Backend side** (`panel/backend/src/services/auto_healer.rs`):
- `auto_renew_agent_certs(pool, agent)` — queries `servers WHERE is_local = TRUE AND agent_acme_cert_domain IS NOT NULL`. Triggers renewal when `agent_acme_cert_expiry - now ≤ 3 days` (50% of 6-day lifetime). 3-hour cooldown per domain. On success: updates `agent_acme_cert_expiry` and `cert_fingerprint`. On failure: increments the new Prom counter.
- Wired into the `run()` loop after `auto_renew_ssl`.

**DB** (`migrations/20260514000000_cert_renewal_failures.sql`):
- `servers.agent_acme_cert_domain TEXT` — opt-in domain for Tier 2 ACME. `NULL` = server uses the self-signed rcgen fallback (no behaviour change).
- `servers.agent_acme_cert_expiry TIMESTAMPTZ` — expiry of the current ACME cert; `NULL` triggers immediate first-time provisioning.

**Renewal cadence correction** — `fallback_renewal_margin("shortlived")` corrected from `Duration::days(2)` to `Duration::days(3)` (50% of 6-day lifetime, up from ≈ 33%). Applies to site certs with `ssl_profile = 'shortlived'` when ARI is unavailable.

### (2) `dockpanel_cert_renewal_failures_total{cert_kind,reason}`

- Rendered by the existing fleet exporter at `GET /api/metrics` (no new scrape endpoint).
- Persisted in new `cert_renewal_failures` DB table (`PRIMARY KEY (cert_kind, reason)`); survives backend restarts unlike in-memory atomics.
- All 15 label combinations pre-seeded at migration time so Prometheus always sees the metric (value 0) before any failure.
- `record_renewal_failure(pool, cert_kind, reason)` — upsert helper called from both `auto_renew_ssl` (site certs → `cert_kind="site"`) and `auto_renew_agent_certs` (Tier 2 → `cert_kind="agent_pinned"`).
- `classify_renewal_error(err)` — pure fn mapping error strings to reason labels; unit tested.

---

## Test

- `cargo build --release` clean on both `panel/backend` and `panel/agent` ✓
- New unit test `acme_renewal_failure_metric_increments` in `prometheus_exporter.rs` — asserts TYPE line, non-zero and zero-value rows render correctly (no DB required).
- New unit tests `classify_rate_limit`, `classify_dns_check`, `classify_network`, `classify_acme_error`, `classify_other` in `auto_healer.rs` — assert error string → reason label mapping.
- `cargo test` > 2 min compile time on cold cache — not blocking per task instructions. Existing `tests/tier2-pin-e2e.sh` covers the TOFU/fingerprint-pin flow unmodified.

---

## Questions for review

1. **Live TLS reload.** The renewed ACME cert is written to disk but the axum-server instance is not hot-reloaded. The new cert takes effect on the next agent restart (systemd `Restart=on-failure` or manual `systemctl restart dockpanel-agent`). Options: (a) `RustlsConfig` dynamic cert resolver via `axum-server`'s `reload()` API — adds complexity but enables zero-downtime rotation; (b) graceful restart signal after write — simpler, brief connection gap. Which approach do you prefer before this merges?

2. **Remote agent cert renewal.** `auto_renew_agent_certs` currently only renews the LOCAL agent (it receives `AgentClient`, not `AgentRegistry`). Remote agents (multi-server fleet) would need `AgentRegistry::for_server` calls. Should `auto_healer::run` be extended to accept `AgentRegistry`, or should remote agent renewal be a separate background service?

3. **HTTP-01 challenge for agent cert.** The agent must serve the HTTP-01 challenge at `/.well-known/acme-challenge/` on port 80. For agents behind a firewall or without a public domain, this will fail with `dns_check` or `acme_error` (the counter will increment, no cert will be provisioned, the self-signed fallback continues to work). Should we add a pre-flight DNS check before attempting the ACME order, and/or surface a panel warning when `agent_acme_cert_domain` is set but HTTP-01 is unreachable?

4. **`panel_public` cert_kind.** The counter schema reserves `cert_kind="panel_public"` for the panel's own public-facing cert (if/when it uses ACME). There is no existing renewal path for this — `panel_public` rows will always be 0. Should we wire it up in this PR or defer to a follow-on?

---

## Files changed

| File | Change |
|---|---|
| `panel/backend/migrations/20260514000000_cert_renewal_failures.sql` | NEW — cert_renewal_failures table + servers columns |
| `panel/backend/src/services/prometheus_exporter.rs` | render_cert_renewal_failures + acme_renewal_failure_metric_increments test |
| `panel/backend/src/services/auto_healer.rs` | shortlived margin 2→3d; record_renewal_failure; auto_renew_agent_certs; classify_renewal_error tests |
| `panel/agent/src/services/ssl.rs` | provision_agent_acme_cert; fingerprint_from_pem; AGENT_ACME_CERT_PATH constants |
| `panel/agent/src/routes/ssl.rs` | POST /ssl/agent/renew; GET /ssl/agent/status |
| `CHANGELOG.md` | [Unreleased] section populated |

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWS1NViJkJDwcWLJUK3Gnd)_