### PR TITLE
feat: Settings → Menu Options, per role, with an admin's own view on top

### DIFF
--- a/panel/backend/src/routes/mod.rs
+++ b/panel/backend/src/routes/mod.rs
@@ -1366,6 +1366,10 @@ pub fn router() -> Router<AppState> {
         .route("/api/logs/check-errors", post(logs::check_errors))
         // Settings (admin)
         .route("/api/settings", get(settings::list).put(settings::update))
+        // The one settings read that is NOT admin-only: an account asking which
+        // menu entries its own role is shown. Deliberately not under
+        // /api/settings/, so it cannot be mistaken for part of the admin surface.
+        .route("/api/menu-options", get(settings::menu_options))
         .route("/api/settings/export", get(settings::export_config))
         .route("/api/settings/import", post(settings::import_config))
         .route("/api/settings/recording-coverage", get(settings::recording_coverage))

--- a/panel/backend/src/routes/settings.rs
+++ b/panel/backend/src/routes/settings.rs
@@ -5,7 +5,7 @@ use axum::{
 };
 use std::collections::HashMap;
 
-use crate::auth::{AdminUser, ServerScope};
+use crate::auth::{AdminUser, AuthUser, ServerScope};
 use crate::error::{internal_error, err, agent_error, ApiError};
 use crate::services::activity;
 use crate::AppState;
@@ -81,6 +81,22 @@ pub const ALLOWED_KEYS: &[&str] = &[
     // AI-assisted build/deploy failure diagnosis (BYO API key, default off).
     // Read by services/ai_diagnosis.rs.
     "ai_diagnosis_enabled", "ai_diagnosis_provider", "ai_diagnosis_model", "ai_diagnosis_api_key",
+    // Which menu entries each role is shown. JSON arrays of nav paths and
+    // `chrome:*` control names, read back by `menu_options` below.
+    //
+    // `menu_hidden_admin` differs from the other three in how binding it is, and
+    // the difference is enforced in the frontend rather than here: for a
+    // non-admin role the stored array IS what that role sees, while for an admin
+    // it is a DEFAULT each administrator may override for their own browser. An
+    // operator debugging a box must always be able to get every door back
+    // without another account's help, because there is no account above them to
+    // restore a row they can no longer find.
+    //
+    // Presentation only. Hiding a row removes the door, not what is behind it:
+    // the route still resolves and every handler still applies the role checks
+    // it always did. Nothing here is a permission, and it must never become the
+    // reason something is BELIEVED to be unreachable.
+    "menu_hidden_admin", "menu_hidden_reseller", "menu_hidden_user", "menu_hidden_client",
     // MCP server (dockpanel-mcp, panel/mcp). Unlike ai_diagnosis_enabled, nothing
     // in the backend or the MCP crate reads these yet — the MCP server's actual
     // on/off state is the systemd unit and its bind address is /etc/dockpanel/
@@ -113,6 +129,41 @@ pub(crate) const SENSITIVE_KEYS: &[&str] = &["smtp_password", "pdns_api_key", "a
 /// back as raw ciphertext, not `********`, on read.
 fn is_sensitive_key(key: &str) -> bool {
     SENSITIVE_KEYS.contains(&key) || key.ends_with("_client_secret")
+}
+
+/// GET /api/menu-options — the menu entries hidden for the CALLER's own role.
+///
+/// Separate from `list` because that handler is `AdminUser`, and the accounts
+/// whose menus this shapes are exactly the ones that cannot call it. Same shape
+/// as `branding`: one narrow, self-scoped read of a table the caller otherwise
+/// has no access to. It answers only for `claims.role`, so no account can learn
+/// what another role's menu looks like.
+///
+/// The role is returned alongside the set because the caller has to know whether
+/// what it just received is binding or merely a default: an administrator may
+/// override their own menu locally, and every other role may not. The frontend
+/// cannot tell those apart from the array alone, and asking it to look the role
+/// up separately is how the two would drift.
+///
+/// A stored value that will not parse is treated as "hide nothing" rather than
+/// as an error. Every caller of this is a menu about to render, and a cluttered
+/// menu is a better failure than an empty one or a page that will not load.
+pub async fn menu_options(
+    State(state): State<AppState>,
+    AuthUser(claims): AuthUser,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let key = format!("menu_hidden_{}", claims.role);
+    let row: Option<(String,)> = sqlx::query_as("SELECT value FROM settings WHERE key = $1")
+        .bind(&key)
+        .fetch_optional(&state.db)
+        .await
+        .map_err(|e| internal_error("read menu options", e))?;
+
+    let hidden: Vec<String> = row
+        .and_then(|(v,)| serde_json::from_str::<Vec<String>>(&v).ok())
+        .unwrap_or_default();
+
+    Ok(Json(serde_json::json!({ "role": claims.role, "hidden": hidden })))
 }
 
 /// GET /api/settings — Returns all settings as a key/value map (admin only).
@@ -176,6 +227,21 @@ pub async fn update(
                 StatusCode::BAD_REQUEST,
                 &format!("Invalid IP or CIDR in allowed_panel_ips: {bad}"),
             ));
+        }
+    }
+
+    // Reject a malformed menu_hidden_* array BEFORE storing it. Every layout
+    // parses this on render and falls back to "show everything" when it cannot,
+    // so a bad value does not fail loudly anywhere — it just makes the
+    // checkboxes look like they did nothing, on somebody else's screen.
+    for (key, value) in &body {
+        if key.starts_with("menu_hidden_") && !value.is_empty() {
+            if let Err(e) = serde_json::from_str::<Vec<String>>(value) {
+                return Err(err(
+                    StatusCode::BAD_REQUEST,
+                    &format!("{key} must be a JSON array of strings: {e}"),
+                ));
+            }
         }
     }
 

--- a/panel/frontend/src/components/AtlasLayout.tsx
+++ b/panel/frontend/src/components/AtlasLayout.tsx
@@ -5,6 +5,7 @@ import { useServer } from "../context/ServerContext";
 import { Icon } from "../data/icons";
 import CommandPalette from "./CommandPalette";
 import LayoutSwitcher from "./LayoutSwitcher";
+import { isMenuHidden } from "../data/menuOptions";
 
 export default function AtlasLayout() {
   const {
@@ -23,8 +24,11 @@ export default function AtlasLayout() {
     sidebarOpen,
     setSidebarOpen,
     visibleGroups,
+    hiddenMenu,
   } = useLayoutState();
   const isLight = theme === "clean" || theme === "arctic";
+  /** Has the operator switched this top-bar control off in Settings → Menu Options? */
+  const hide = (key: string) => isMenuHidden(key, hiddenMenu);
   const { servers, activeServer, setActiveServerId } = useServer();
 
   const location = useLocation();
@@ -168,7 +172,7 @@ export default function AtlasLayout() {
           {/* Right actions */}
           <div className="flex items-center gap-2 shrink-0 ml-auto md:ml-4">
             {/* Server selector */}
-            {servers.length > 1 && (
+            {servers.length > 1 && !hide("chrome:serverSelector") && (
               <select
                 value={activeServer?.id || ""}
                 onChange={e => { setActiveServerId(e.target.value); window.location.href = "/"; }}
@@ -178,6 +182,7 @@ export default function AtlasLayout() {
               </select>
             )}
             {/* Search */}
+            {!hide("chrome:search") && (
             <button
               onClick={() =>
                 window.dispatchEvent(
@@ -190,6 +195,7 @@ export default function AtlasLayout() {
             >
               <Icon name="search" className="w-4 h-4" />
             </button>
+            )}
 
             {/* Alert badge */}
             {firingCount > 0 && (
@@ -203,7 +209,7 @@ export default function AtlasLayout() {
             )}
 
             {/* Health dot — admins only; see `canSeeHealth` in useLayoutState. */}
-            {canSeeHealth && (
+            {canSeeHealth && !hide("chrome:health") && (
               <div
                 className={`w-2 h-2 rounded-full ${
                   apiHealthy === null
@@ -223,6 +229,7 @@ export default function AtlasLayout() {
             )}
 
             {/* Notification bell */}
+            {!hide("chrome:notifications") && (
             <Link to="/notifications" className="relative p-1.5 text-dark-300 hover:text-dark-100 rounded-md hover:bg-dark-700/30" title={notifCount > 0 ? `${notifCount} unread notification${notifCount === 1 ? "" : "s"}` : "Notifications"} aria-label="Notifications">
               <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M14.857 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75v-.7V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 01-5.714 0m5.714 0a3 3 0 11-5.714 0" />
@@ -233,11 +240,13 @@ export default function AtlasLayout() {
                 </span>
               )}
             </Link>
+            )}
 
             {/* Layout switcher */}
-            <LayoutSwitcher variant={isLight ? "light" : "dark"} />
+            {!hide("chrome:layoutSwitcher") && <LayoutSwitcher variant={isLight ? "light" : "dark"} />}
 
             {/* Theme cycle */}
+            {!hide("chrome:themeToggle") && (
             <button
               onClick={cycleTheme}
               className="p-1.5 text-dark-300 hover:text-dark-100 rounded-md hover:bg-dark-700/30"
@@ -259,6 +268,7 @@ export default function AtlasLayout() {
                 />
               </svg>
             </button>
+            )}
 
             {/* User */}
             <div className="flex items-center gap-2 pl-2 border-l border-dark-600">

--- a/panel/frontend/src/components/CommandLayout.tsx
+++ b/panel/frontend/src/components/CommandLayout.tsx
@@ -5,6 +5,7 @@ import { useBranding } from "../context/BrandingContext";
 import { Icon } from "../data/icons";
 import CommandPalette from "./CommandPalette";
 import LayoutSwitcher from "./LayoutSwitcher";
+import { isMenuHidden } from "../data/menuOptions";
 import { useState, useRef, useEffect } from "react";
 
 function ServerSelector() {
@@ -58,6 +59,8 @@ export default function CommandLayout() {
   const state = useLayoutState();
   const branding = useBranding();
   const isLight = state.theme === "clean" || state.theme === "arctic";
+  /** Has the operator switched this top-bar control off in Settings → Menu Options? */
+  const hide = (key: string) => isMenuHidden(key, state.hiddenMenu);
 
   // Layout options (persisted in localStorage)
   const [showHeader, setShowHeader] = useState(() => localStorage.getItem("dp-show-header") === "true");
@@ -152,7 +155,7 @@ export default function CommandLayout() {
         </div>
 
         {/* Search shortcut (hide if header has search) */}
-        {!showHeader && (
+        {!showHeader && !hide("chrome:search") && (
           <div className="px-3 pt-3 pb-1">
             <button
               onClick={() => window.dispatchEvent(new KeyboardEvent("keydown", { key: "k", ctrlKey: true }))}
@@ -165,7 +168,7 @@ export default function CommandLayout() {
           </div>
         )}
 
-        <ServerSelector />
+        {!hide("chrome:serverSelector") && <ServerSelector />}
 
         {/* Nav */}
         <nav className="flex-1 px-3 pt-4 overflow-y-auto sidebar-scroll-fade">
@@ -307,7 +310,7 @@ export default function CommandLayout() {
             </div>
             <div className="flex items-center justify-between px-3 mt-2">
               <div className="flex items-center gap-2">
-                {state.canSeeHealth && (
+                {state.canSeeHealth && !hide("chrome:health") && (
                   <>
                     <div className={`w-1.5 h-1.5 rounded-full shrink-0 ${state.apiHealthy === null ? "bg-dark-400" : state.apiHealthy ? "bg-rust-500" : "bg-danger-500 animate-pulse"}`} />
                     <span className="text-[10px] text-dark-400">{state.apiHealthy === null ? "Checking..." : state.apiHealthy ? "Connected" : "Disconnected"}</span>
@@ -315,6 +318,7 @@ export default function CommandLayout() {
                 )}
               </div>
               <div className="flex items-center gap-1">
+                {!hide("chrome:notifications") && (
                 <Link to="/notifications" className="relative p-1.5 text-dark-400 hover:text-dark-200 transition-colors rounded" title={state.notifCount > 0 ? `${state.notifCount} unread notification${state.notifCount === 1 ? "" : "s"}` : "Notifications"} aria-label="Notifications">
                   <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
                     <path strokeLinecap="round" strokeLinejoin="round" d="M14.857 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75v-.7V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 01-5.714 0m5.714 0a3 3 0 11-5.714 0" />
@@ -325,7 +329,9 @@ export default function CommandLayout() {
                     </span>
                   )}
                 </Link>
-                <LayoutSwitcher variant={isLight ? "light" : "dark"} />
+                )}
+                {!hide("chrome:layoutSwitcher") && <LayoutSwitcher variant={isLight ? "light" : "dark"} />}
+                {!hide("chrome:themeToggle") && (
                 <button
                   onClick={state.cycleTheme}
                   className="p-1.5 text-dark-400 hover:text-dark-200 transition-colors rounded"
@@ -336,13 +342,14 @@ export default function CommandLayout() {
                     <path strokeLinecap="round" strokeLinejoin="round" d="M4.098 19.902a3.75 3.75 0 0 0 5.304 0l6.401-6.402M6.75 21A3.75 3.75 0 0 1 3 17.25V4.125C3 3.504 3.504 3 4.125 3h5.25c.621 0 1.125.504 1.125 1.125v4.072M6.75 21a3.75 3.75 0 0 0 3.75-3.75V8.197M6.75 21h13.125c.621 0 1.125-.504 1.125-1.125v-5.25c0-.621-.504-1.125-1.125-1.125h-4.072M10.5 8.197l2.88-2.88c.438-.439 1.15-.439 1.59 0l3.712 3.713c.44.44.44 1.152 0 1.59l-2.88 2.88M6.75 17.25h.008v.008H6.75v-.008Z" />
                   </svg>
                 </button>
+                )}
               </div>
             </div>
           </div>
         )}
 
         {/* Minimal sidebar footer when header is shown */}
-        {showHeader && state.canSeeHealth && (
+        {showHeader && state.canSeeHealth && !hide("chrome:health") && (
           <div className="px-4 py-3 border-t border-dark-600/50">
             <div className="flex items-center gap-2">
               <div className={`w-2 h-2 rounded-full shrink-0 ${state.apiHealthy === null ? "bg-dark-400" : state.apiHealthy ? "bg-rust-500" : "bg-danger-500 animate-pulse"}`} />
@@ -368,6 +375,7 @@ export default function CommandLayout() {
 
             {/* Search */}
             <div className="flex-1 flex items-center max-w-md">
+              {!hide("chrome:search") && (
               <button
                 onClick={() => window.dispatchEvent(new KeyboardEvent("keydown", { key: "k", ctrlKey: true }))}
                 className="w-full flex items-center gap-2 pl-3 pr-4 py-2 border rounded-lg text-sm transition-all bg-dark-950 border-dark-700 text-dark-400 hover:border-rust-500/50"
@@ -376,10 +384,12 @@ export default function CommandLayout() {
                 <span className="flex-1 text-left">Search...</span>
                 <kbd className="text-[10px] px-1.5 py-0.5 border rounded border-dark-700 bg-dark-800 text-dark-400">Ctrl K</kbd>
               </button>
+              )}
             </div>
 
             {/* Right side */}
             <div className="flex items-center gap-3">
+              {!hide("chrome:notifications") && (
               <Link to="/notifications" className="relative p-2 rounded-lg transition-colors text-dark-400 hover:text-dark-50 hover:bg-dark-800" title={state.notifCount > 0 ? `${state.notifCount} unread notification${state.notifCount === 1 ? "" : "s"}` : "Notifications"} aria-label="Notifications">
                 <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
                   <path strokeLinecap="round" strokeLinejoin="round" d="M14.857 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75v-.7V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 01-5.714 0m5.714 0a3 3 0 11-5.714 0" />
@@ -390,6 +400,7 @@ export default function CommandLayout() {
                   </span>
                 )}
               </Link>
+              )}
               {/* This pill sat next to the notification bell drawing the SAME
                   bell glyph over a different number, so the header showed two
                   identical icons meaning unrelated things. A firing alert is not
@@ -405,12 +416,16 @@ export default function CommandLayout() {
                 </Link>
               )}
               <div className="h-6 w-px hidden sm:block bg-dark-700" />
+              {!hide("chrome:themeToggle") && (
               <button onClick={state.cycleTheme} className="p-2 rounded-lg transition-colors text-dark-400 hover:text-dark-50 hover:bg-dark-800" title={`Theme: ${state.theme}`}>
                 <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
                   <path strokeLinecap="round" strokeLinejoin="round" d="M4.098 19.902a3.75 3.75 0 0 0 5.304 0l6.401-6.402M6.75 21A3.75 3.75 0 0 1 3 17.25V4.125C3 3.504 3.504 3 4.125 3h5.25c.621 0 1.125.504 1.125 1.125v4.072M6.75 21a3.75 3.75 0 0 0 3.75-3.75V8.197M6.75 21h13.125c.621 0 1.125-.504 1.125-1.125v-5.25c0-.621-.504-1.125-1.125-1.125h-4.072M10.5 8.197l2.88-2.88c.438-.439 1.15-.439 1.59 0l3.712 3.713c.44.44.44 1.152 0 1.59l-2.88 2.88M6.75 17.25h.008v.008H6.75v-.008Z" />
                 </svg>
               </button>
-              <div className="hidden sm:block"><LayoutSwitcher variant={isLight ? "light" : "dark"} /></div>
+              )}
+              {!hide("chrome:layoutSwitcher") && (
+                <div className="hidden sm:block"><LayoutSwitcher variant={isLight ? "light" : "dark"} /></div>
+              )}
               <div className="hidden sm:flex items-center gap-2">
                 <div className="w-8 h-8 rounded-full flex items-center justify-center font-semibold text-sm bg-rust-500/15 text-rust-400">
                   {state.user.email[0]?.toUpperCase()}

--- a/panel/frontend/src/components/CommandPalette.tsx
+++ b/panel/frontend/src/components/CommandPalette.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "../context/AuthContext";
 import { isNavVisible, navFlagsFor } from "../data/navItems";
+import { isMenuHidden, useHiddenMenu } from "../data/menuOptions";
 
 interface Command {
   id: string;
@@ -18,6 +19,7 @@ interface Command {
 
 export default function CommandPalette() {
   const { user } = useAuth();
+  const hiddenMenu = useHiddenMenu();
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -75,10 +77,21 @@ export default function CommandPalette() {
   // Same predicate, same registry as the sidebar. A command whose path has no
   // nav row (none today) is treated as unrestricted — this is a menu, and every
   // destination still enforces its own access on arrival.
+  //
+  // The hidden-menu preference applies here for the same reason the role test
+  // was extracted in the first place: this palette IS a second menu over the
+  // same pages, and an operator who switched a row off in Settings has said
+  // they do not want to be offered it. Typing the URL still works — hiding is
+  // presentation, not restriction.
   const allowed = useMemo(
-    () => commands.filter((c) => isNavVisible(navFlagsFor(c.path), user?.role ?? "")),
+    () =>
+      commands.filter(
+        (c) =>
+          isNavVisible(navFlagsFor(c.path), user?.role ?? "") &&
+          !isMenuHidden(c.path, hiddenMenu),
+      ),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [user?.role],
+    [user?.role, hiddenMenu],
   );
 
   const filtered = query

--- a/panel/frontend/src/components/GlassLayout.tsx
+++ b/panel/frontend/src/components/GlassLayout.tsx
@@ -5,6 +5,7 @@ import { useServer } from "../context/ServerContext";
 import { Icon } from "../data/icons";
 import CommandPalette from "./CommandPalette";
 import LayoutSwitcher from "./LayoutSwitcher";
+import { isMenuHidden } from "../data/menuOptions";
 
 export default function GlassLayout() {
   const {
@@ -23,8 +24,11 @@ export default function GlassLayout() {
     sidebarOpen,
     setSidebarOpen,
     visibleGroups,
+    hiddenMenu,
   } = useLayoutState();
   const isLight = theme === "clean" || theme === "arctic";
+  /** Has the operator switched this top-bar control off in Settings → Menu Options? */
+  const hide = (key: string) => isMenuHidden(key, hiddenMenu);
   const { servers, activeServer, setActiveServerId } = useServer();
 
   const [hovered, setHovered] = useState(false);
@@ -125,6 +129,7 @@ export default function GlassLayout() {
         </div>
 
         {/* ── Search shortcut (visible when expanded) ───────────── */}
+        {!hide("chrome:search") && (
         <div
           className={[
             "px-3 pt-3 pb-1 transition-opacity duration-200",
@@ -146,9 +151,10 @@ export default function GlassLayout() {
             </kbd>
           </button>
         </div>
+        )}
 
         {/* Server selector (expanded only) */}
-        {servers.length > 1 && (expanded || sidebarOpen) && (
+        {servers.length > 1 && (expanded || sidebarOpen) && !hide("chrome:serverSelector") && (
           <div className="px-3 pt-2">
             <select
               value={activeServer?.id || ""}
@@ -293,7 +299,7 @@ export default function GlassLayout() {
         {/* ── Footer ─────────────────────────────────────────────── */}
         <div className="px-2 py-3 border-t border-dark-600/30">
           {/* Collapsed: just the health dot centered — admins only. */}
-          {!expanded && !sidebarOpen && canSeeHealth && (
+          {!expanded && !sidebarOpen && canSeeHealth && !hide("chrome:health") && (
             <div className="flex flex-col items-center gap-3">
               <div
                 className={[
@@ -340,7 +346,7 @@ export default function GlassLayout() {
               {/* Health + layout + theme */}
               <div className="flex items-center justify-between px-3 mt-2">
                 <div className="flex items-center gap-2">
-                  {canSeeHealth && (
+                  {canSeeHealth && !hide("chrome:health") && (
                     <>
                       <div
                         className={[
@@ -359,6 +365,7 @@ export default function GlassLayout() {
                   )}
                 </div>
                 <div className="flex items-center gap-1">
+                {!hide("chrome:notifications") && (
                 <Link to="/notifications" className="relative p-1.5 text-dark-400 hover:text-dark-200 transition-colors rounded shrink-0" title={notifCount > 0 ? `${notifCount} unread notification${notifCount === 1 ? "" : "s"}` : "Notifications"} aria-label="Notifications">
                   <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
                     <path strokeLinecap="round" strokeLinejoin="round" d="M14.857 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75v-.7V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 01-5.714 0m5.714 0a3 3 0 11-5.714 0" />
@@ -369,7 +376,9 @@ export default function GlassLayout() {
                     </span>
                   )}
                 </Link>
-                <LayoutSwitcher variant={isLight ? "light" : "dark"} compact />
+                )}
+                {!hide("chrome:layoutSwitcher") && <LayoutSwitcher variant={isLight ? "light" : "dark"} compact />}
+                {!hide("chrome:themeToggle") && (
                 <button
                   onClick={cycleTheme}
                   className="p-1.5 text-dark-400 hover:text-dark-200 transition-colors rounded shrink-0"
@@ -390,6 +399,7 @@ export default function GlassLayout() {
                     />
                   </svg>
                 </button>
+                )}
                 </div>
               </div>
             </div>

--- a/panel/frontend/src/data/menuOptions.ts
+++ b/panel/frontend/src/data/menuOptions.ts
@@ -1,0 +1,252 @@
+import { useEffect, useState } from "react";
+import { api } from "../api";
+import { navGroups, type NavGroup } from "./navItems";
+
+/**
+ * Which menu entries a role is shown.
+ *
+ * Set by an administrator, per role, and stored panel-side in the `settings`
+ * table under `menu_hidden_{role}` — so it applies to everyone with that role on
+ * every browser they use, not to whoever happened to tick a box.
+ *
+ * This is a PREFERENCE, not a permission. Hiding a row removes the door, not
+ * what is behind it: the route still resolves, the URL still works, and the
+ * handler still applies whatever role check it always did. `isNavVisible` in
+ * `navItems.ts` answers the other question — may this account be OFFERED this
+ * page — and the two are deliberately kept apart. Folding decluttering into the
+ * permission predicate would make a checkbox in Settings look like a security
+ * control, and would invite someone to hide a row INSTEAD of restricting it.
+ */
+
+/**
+ * Fired after an administrator saves, so every mounted menu re-reads.
+ *
+ * Same bus pattern as `THEME_CHANGE_EVENT`. It only reaches the tab that saved:
+ * other sessions pick the change up on their next load, which is the right
+ * cadence for a setting an operator changes once.
+ */
+export const MENU_CHANGE_EVENT = "dp-menu-change";
+
+/** The roles an administrator may configure. */
+export const CONFIGURABLE_ROLES = ["admin", "reseller", "user", "client"] as const;
+export type ConfigurableRole = (typeof CONFIGURABLE_ROLES)[number];
+
+/**
+ * One administrator's own menu, overriding the stored `admin` default.
+ *
+ * The admin row is the only one that is a DEFAULT rather than a decision. An
+ * operator debugging a box has to be able to get every door back without
+ * another account's help — there is no account above an admin to restore a row
+ * they can no longer find — so an admin may set their own view here and a
+ * non-admin may not.
+ *
+ * Per browser, beside `dp-theme` and `dp-layout`, because it is the same kind of
+ * choice: what THIS person wants to look at, not what the panel is configured to
+ * be. Absent means "follow the stored default", which is why it is removed
+ * rather than emptied when an admin goes back to it — an empty array is a real
+ * answer meaning "hide nothing".
+ */
+export const ADMIN_OVERRIDE_KEY = "dp-menu-admin-override";
+
+/** The calling admin's own menu, or null when they follow the default. */
+export function readAdminOverride(): Set<string> | null {
+  try {
+    const raw = localStorage.getItem(ADMIN_OVERRIDE_KEY);
+    if (raw === null) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return null;
+    return new Set(parsed.filter((v): v is string => typeof v === "string" && !isAlwaysVisible(v)));
+  } catch {
+    return null;
+  }
+}
+
+/** Set this admin's own menu, or pass null to go back to the stored default. */
+export function writeAdminOverride(hidden: Set<string> | null): void {
+  try {
+    if (hidden === null) localStorage.removeItem(ADMIN_OVERRIDE_KEY);
+    else localStorage.setItem(ADMIN_OVERRIDE_KEY, JSON.stringify([...hidden].filter(k => !isAlwaysVisible(k))));
+  } catch {
+    // Storage full or blocked. The event below still fires, so the change
+    // applies for this session even when it cannot be remembered.
+  }
+  window.dispatchEvent(new Event(MENU_CHANGE_EVENT));
+}
+
+/**
+ * The rows no checkbox may ever turn off.
+ *
+ * Dashboard is where every layout's logo links and where a refused route lands,
+ * so losing it strands the account. Settings is the only way BACK to these
+ * checkboxes. My Account is the sole entry every role can see (see the comment
+ * on that row in `navItems.ts`) and the 2FA banner in all three layouts points
+ * at it — hiding it from a `client` would leave the panel nagging them to enrol
+ * with no screen on which to do it.
+ */
+export const ALWAYS_VISIBLE_PATHS: readonly string[] = ["/", "/settings", "/account"];
+
+export function isAlwaysVisible(path: string): boolean {
+  return ALWAYS_VISIBLE_PATHS.includes(path);
+}
+
+/**
+ * The top-bar controls, which have no registry of their own.
+ *
+ * `navGroups` covers the side menu because every row there is a route. These are
+ * not routes — they are the chrome each layout draws around the outlet — so they
+ * are enumerated here and keyed by name. The keys are prefixed `chrome:` so one
+ * flat stored array can hold both kinds without a control name ever colliding
+ * with a path.
+ *
+ * The signed-in username and its Logout button are deliberately absent: an
+ * account must always be able to see who it is signed in as, and sign out.
+ */
+export interface ChromeItem {
+  key: string;
+  label: string;
+  hint: string;
+}
+
+export const CHROME_ITEMS: readonly ChromeItem[] = [
+  { key: "chrome:search", label: "Search box", hint: "The Ctrl-K search shortcut. The keyboard shortcut itself keeps working." },
+  { key: "chrome:notifications", label: "Notifications bell", hint: "The bell and its unread badge." },
+  { key: "chrome:serverSelector", label: "Server selector", hint: "The fleet server picker above the navigation." },
+  { key: "chrome:layoutSwitcher", label: "Layout switcher", hint: "The control that changes between the Command, Glass and Atlas layouts." },
+  { key: "chrome:themeToggle", label: "Theme toggle", hint: "The button that cycles the colour theme." },
+  { key: "chrome:health", label: "Connection status", hint: "The host-health dot and its Connected / Disconnected label." },
+];
+
+/** What the panel stores for this account's role, before any admin override. */
+export interface MenuDefault {
+  role: string;
+  hidden: Set<string>;
+}
+
+// One fetch per session, shared by the three layouts, the command palette and
+// the dashboard. Without the cache each of those mounts its own request for the
+// same tiny answer, and the sidebar would re-request it on every layout switch.
+let cache: MenuDefault | null = null;
+let inflight: Promise<MenuDefault> | null = null;
+
+/**
+ * The stored menu for the CURRENT account's role, from `GET /api/menu-options`.
+ *
+ * Never rejects. A failure — offline, a 500, a logged-out 401 — resolves to an
+ * empty set, because every caller is a menu about to render and a cluttered
+ * menu is a better failure than an empty one.
+ */
+export function loadMenuDefault(force = false): Promise<MenuDefault> {
+  if (force) {
+    cache = null;
+    inflight = null;
+  }
+  if (cache) return Promise.resolve(cache);
+  if (inflight) return inflight;
+
+  inflight = api
+    .get<{ role?: string; hidden?: string[] }>("/menu-options")
+    .then(r => {
+      const hidden = Array.isArray(r?.hidden) ? r.hidden : [];
+      // An always-visible path that somehow reached the store is dropped on READ
+      // as well as on write: a value written by an older build, or edited into
+      // the table by hand, must not be able to strand an account.
+      cache = {
+        role: typeof r?.role === "string" ? r.role : "",
+        hidden: new Set(hidden.filter(k => typeof k === "string" && !isAlwaysVisible(k))),
+      };
+      return cache;
+    })
+    .catch(() => {
+      cache = { role: "", hidden: new Set<string>() };
+      return cache;
+    })
+    .finally(() => {
+      inflight = null;
+    });
+
+  return inflight;
+}
+
+/** Drop the cached answer. Called after an admin saves, and on logout, so the
+ *  next account does not inherit the previous one's menu. */
+export function invalidateHiddenMenu(): void {
+  cache = null;
+  inflight = null;
+  window.dispatchEvent(new Event(MENU_CHANGE_EVENT));
+}
+
+/**
+ * Resolve what this account actually sees: the stored default for its role,
+ * replaced wholesale by this admin's own choice when they have made one.
+ *
+ * The override is honoured ONLY for an admin, and the role comes from the server
+ * rather than from localStorage, so a stale or hand-edited `dp-menu-admin-
+ * override` cannot reshape a `user`'s menu. That matters less than it sounds —
+ * none of this is a permission — but a setting an administrator made for a role
+ * should not be quietly undone by something in that person's own browser.
+ */
+export function resolveHiddenMenu(base: MenuDefault): Set<string> {
+  if (base.role !== "admin") return base.hidden;
+  return readAdminOverride() ?? base.hidden;
+}
+
+/**
+ * Subscribe to the hidden set for this account.
+ *
+ * Starts empty and fills in when the fetch lands, so a menu renders complete and
+ * then settles rather than blocking on a request. Only rows this account is
+ * permitted to see are ever in that first paint — the role filter in
+ * `isNavVisible` is synchronous and does not wait for this.
+ */
+export function useHiddenMenu(): Set<string> {
+  const [hidden, setHidden] = useState<Set<string>>(() => (cache ? resolveHiddenMenu(cache) : new Set()));
+
+  useEffect(() => {
+    let alive = true;
+    const load = () => {
+      loadMenuDefault().then(next => {
+        if (alive) setHidden(resolveHiddenMenu(next));
+      });
+    };
+    load();
+    window.addEventListener(MENU_CHANGE_EVENT, load);
+    // An admin editing their own view in another tab.
+    window.addEventListener("storage", load);
+    return () => {
+      alive = false;
+      window.removeEventListener(MENU_CHANGE_EVENT, load);
+      window.removeEventListener("storage", load);
+    };
+  }, []);
+
+  return hidden;
+}
+
+/**
+ * Is this menu entry hidden? `key` is a nav path or a `chrome:` control name.
+ *
+ * The always-visible check lives here as well as at the read, so a row cannot be
+ * hidden by any route into this module.
+ */
+export function isMenuHidden(key: string, hidden: Set<string>): boolean {
+  if (isAlwaysVisible(key)) return false;
+  return hidden.has(key);
+}
+
+/**
+ * The nav rows a checkbox may turn off, in the order the sidebar draws them.
+ *
+ * Derived from `navGroups` rather than restated, so a row added to the registry
+ * gets a checkbox automatically. A hardcoded second list is precisely how the
+ * command palette came to offer pages the sidebar did not.
+ *
+ * Not filtered by role. An administrator configuring the `client` menu is
+ * choosing from every row that exists, and `isNavVisible` still removes the ones
+ * that role could never reach — so a box ticked here for a page a client cannot
+ * open changes nothing, rather than being a trap.
+ */
+export function toggleableNavGroups(): NavGroup[] {
+  return navGroups
+    .map(g => ({ ...g, items: g.items.filter(item => !isAlwaysVisible(item.to)) }))
+    .filter(g => g.items.length > 0);
+}

--- a/panel/frontend/src/hooks/useLayoutState.ts
+++ b/panel/frontend/src/hooks/useLayoutState.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useMemo } from "react";
 import { useAuth } from "../context/AuthContext";
 import { api } from "../api";
 import { navGroups, isNavVisible, type NavGroup } from "../data/navItems";
+import { isMenuHidden, useHiddenMenu } from "../data/menuOptions";
 
 const themeOrder = ["terminal", "midnight", "ember", "arctic", "clean", "clean-dark"] as const;
 
@@ -87,10 +88,15 @@ export interface LayoutState {
   sidebarOpen: boolean;
   setSidebarOpen: (v: boolean) => void;
   visibleGroups: NavGroup[];
+  /** Top-bar controls the operator has switched off, keyed `chrome:*`. Read it
+   *  through `isMenuHidden` rather than `.has`, so the always-visible rule is
+   *  applied the one way everywhere. */
+  hiddenMenu: Set<string>;
 }
 
 export function useLayoutState(): LayoutState {
   const { user, logout, loading } = useAuth();
+  const hiddenMenu = useHiddenMenu();
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [firingCount, setFiringCount] = useState(0);
   const [incidentCount, setIncidentCount] = useState(0);
@@ -224,16 +230,24 @@ export function useLayoutState(): LayoutState {
       .catch(() => {});
   }, []);
 
-  // Filter nav groups by role
+  // Filter nav groups by role, then by what the operator has chosen to hide.
+  //
+  // Two filters and not one, because they answer different questions. The role
+  // test says whether this account may be OFFERED the page at all; the hidden
+  // test is a per-browser decluttering preference over what is left. Only the
+  // first is a restriction — a hidden row's route still resolves, which is why
+  // it must not be folded into `isNavVisible`.
   const visibleGroups = useMemo(() => {
     if (!user) return [];
     return navGroups.map(g => ({
       ...g,
       // Extracted to `navItems.ts` so the command palette can read the same
       // decision instead of having its own (it had none at all).
-      items: g.items.filter(item => isNavVisible(item, user.role)),
+      items: g.items.filter(
+        item => isNavVisible(item, user.role) && !isMenuHidden(item.to, hiddenMenu),
+      ),
     })).filter(g => g.items.length > 0);
-  }, [user]);
+  }, [user, hiddenMenu]);
 
   return {
     user: user || { email: "", role: "" },
@@ -253,5 +267,6 @@ export function useLayoutState(): LayoutState {
     sidebarOpen,
     setSidebarOpen,
     visibleGroups,
+    hiddenMenu,
   };
 }

--- a/panel/frontend/src/pages/Dashboard.tsx
+++ b/panel/frontend/src/pages/Dashboard.tsx
@@ -4,6 +4,7 @@ import { api } from "../api";
 import { useServer } from "../context/ServerContext";
 import { useAuth } from "../context/AuthContext";
 import { isNavVisible, navFlagsFor } from "../data/navItems";
+import { isMenuHidden, useHiddenMenu } from "../data/menuOptions";
 import { formatSize, formatRate, formatUptime, timeAgo } from "../utils/format";
 
 interface SiteDetail {
@@ -275,6 +276,7 @@ export default function Dashboard() {
   // indistinguishable from having no access to their own site. Reported that
   // way on #51, twice, by an operator who was testing a client account.
   const { user } = useAuth();
+  const hiddenMenu = useHiddenMenu();
   const isAdmin = user?.role === "admin";
 
   const [system, setSystem] = useState<SystemInfo | null>(null);
@@ -792,7 +794,12 @@ export default function Dashboard() {
               back here, and every handler in `routes/docker_apps.rs` requires
               admin. Docker Apps is an operator capability, so say so by not
               offering it. */}
-          {isAdmin && (
+          {/* Also gated on the Docker Apps menu checkbox. This shortcut and the
+              /apps sidebar row are one decision wearing two hats: an operator
+              who switched that row off has said they do not work with Docker
+              Apps on this box, and leaving the button here would put the thing
+              they hid back on the first screen they see. */}
+          {isAdmin && !isMenuHidden("/apps", hiddenMenu) && (
             <Link to="/apps" className="hidden sm:flex px-3 py-1.5 bg-dark-800 text-dark-300 hover:bg-dark-700 hover:text-dark-100 border border-dark-600 rounded-lg text-xs font-medium items-center gap-1.5 transition-colors">
               <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" /></svg>
               Deploy App
@@ -800,8 +807,9 @@ export default function Dashboard() {
           )}
           {/* A `client` cannot bring a new domain into service by any route, so
               offering it the shortcut named for exactly that is a dead end —
-              it lands on the one refusal the role is defined by. */}
-          {user?.role !== "client" && (
+              it lands on the one refusal the role is defined by.
+              Gated on the Sites menu checkbox too, for the reason above. */}
+          {user?.role !== "client" && !isMenuHidden("/sites", hiddenMenu) && (
             <Link to="/sites" className="px-3 py-1.5 bg-dark-800 text-dark-300 hover:bg-dark-700 hover:text-dark-100 border border-dark-600 rounded-lg text-xs font-medium flex items-center gap-1.5 transition-colors">
               <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" /></svg>
               Add Site

--- a/panel/frontend/src/pages/Settings.tsx
+++ b/panel/frontend/src/pages/Settings.tsx
@@ -6,6 +6,15 @@ import ProvisionLog from "../components/ProvisionLog";
 import UpdatesContent from "./Updates";
 import { timeAgo } from "../utils/format";
 import { applyTheme, readStoredTheme } from "../hooks/useLayoutState";
+import {
+  CHROME_ITEMS,
+  CONFIGURABLE_ROLES,
+  invalidateHiddenMenu,
+  readAdminOverride,
+  toggleableNavGroups,
+  writeAdminOverride,
+  type ConfigurableRole,
+} from "../data/menuOptions";
 import ConfirmDialog from "../components/ConfirmDialog";
 import {
   TwoFactorCard,
@@ -181,6 +190,15 @@ const NOTIF_PLACEHOLDERS = ["{{title}}", "{{message}}", "{{severity}}", "{{times
 
 export default function Settings() {
   const { user } = useAuth();
+  const [menuRole, setMenuRole] = useState<ConfigurableRole>("admin");
+  const [menuSaving, setMenuSaving] = useState(false);
+  /** Which admin menu the checkboxes edit: the stored default every admin
+   *  starts from, or this administrator's own override. Meaningless for the
+   *  other roles, whose stored array is simply what they get. */
+  const [adminScope, setAdminScope] = useState<"default" | "mine">("default");
+  /** localStorage is not reactive; bumped after an override write so the
+   *  checkboxes re-read it. */
+  const [overrideTick, setOverrideTick] = useState(0);
   const [settings, setSettings] = useState<Record<string, string>>({});
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState<string | null>(null);
@@ -287,6 +305,64 @@ export default function Settings() {
   const [canary, setCanary] = useState<{ enabled: boolean; watching: number; total: number; armable: number; paths: { path: string; state: string; plantable: boolean; detail: string | null }[] } | null>(null);
   const [canaryErr, setCanaryErr] = useState<string | null>(null);
   const [arming, setArming] = useState(false);
+
+  /** The hidden set stored for one role, from the settings map already loaded.
+   *  A value that will not parse reads as "hide nothing", the same way the
+   *  backend and the layouts treat it — three places that must not disagree
+   *  about a malformed row, or the checkboxes would show one thing and the
+   *  role's menu another. */
+  const menuHiddenFor = (role: string): Set<string> => {
+    try {
+      const parsed: unknown = JSON.parse(settings[`menu_hidden_${role}`] || "[]");
+      return new Set(Array.isArray(parsed) ? parsed.filter((v): v is string => typeof v === "string") : []);
+    } catch {
+      return new Set<string>();
+    }
+  };
+
+  /** True when the checkboxes are editing this administrator's own view rather
+   *  than a stored role default. */
+  const editingOwnAdminView = menuRole === "admin" && adminScope === "mine";
+
+  /** The set the checkboxes currently reflect. An admin who has never overridden
+   *  starts from the stored default, so switching to "just me" shows what they
+   *  have rather than an empty slate. */
+  const menuEditingSet = (): Set<string> => {
+    void overrideTick;
+    if (editingOwnAdminView) return readAdminOverride() ?? menuHiddenFor("admin");
+    return menuHiddenFor(menuRole);
+  };
+
+  /** Saves on every tick, like the auto-heal and status-page switches on this
+   *  page. A Save button here would be one more thing to forget, on a screen
+   *  whose whole purpose is what somebody else sees. */
+  const setMenuEntryShown = async (key: string, shown: boolean) => {
+    const next = menuEditingSet();
+    if (shown) next.delete(key);
+    else next.add(key);
+
+    if (editingOwnAdminView) {
+      writeAdminOverride(next);
+      setOverrideTick(t => t + 1);
+      return;
+    }
+
+    const settingKey = `menu_hidden_${menuRole}`;
+    const value = JSON.stringify([...next]);
+    setMenuSaving(true);
+    try {
+      await api.put("/settings", { [settingKey]: value });
+      setSettings(s => ({ ...s, [settingKey]: value }));
+      // This admin's own sidebar re-reads on the event; an admin following the
+      // default sees their change immediately, one with an override does not,
+      // which is exactly what having an override means.
+      invalidateHiddenMenu();
+    } catch (e) {
+      setMessage({ text: e instanceof Error ? e.message : "Failed to save menu options", type: "error" });
+    } finally {
+      setMenuSaving(false);
+    }
+  };
 
   const loadSettings = async () => {
     try {
@@ -557,7 +633,7 @@ export default function Settings() {
   // to write a correct link even if you wanted to, because nothing here read the
   // URL. "Configure alert channels →" on the notifications page was the instance
   // that surfaced it; there are several more.
-  const SETTINGS_TABS: readonly string[] = ["general", "email", "account", "channels", "services"];
+  const SETTINGS_TABS: readonly string[] = ["general", "email", "account", "channels", "services", "menu"];
   const [searchParams] = useSearchParams();
   const resolveSettingsTab = (raw: string | null): string =>
     raw && SETTINGS_TABS.includes(raw) ? raw : "general";
@@ -600,6 +676,7 @@ export default function Settings() {
           { id: "account", label: "Account" },
           { id: "channels", label: "Alert Channels" },
           { id: "services", label: "Services" },
+          { id: "menu", label: "Menu Options" },
         ].map(t => (
           <button key={t.id} onClick={() => setTab(t.id)}
             className={`flex items-center gap-1.5 px-3 py-2 text-sm font-medium rounded-t-lg transition-colors whitespace-nowrap shrink-0 ${
@@ -2507,6 +2584,146 @@ export default function Settings() {
                 </div>
               </div>
             )}
+          </div>
+        </div>
+        </>)}
+
+        {/* Menu Options */}
+        {tab === "menu" && (<>
+        <div className="bg-dark-800 rounded-lg border border-dark-500 overflow-hidden">
+          <div className="px-5 py-3 border-b border-dark-600">
+            <div className="flex items-center justify-between gap-4 flex-wrap">
+              <div>
+                <h3 className="text-xs font-medium text-dark-300 uppercase font-mono tracking-widest">Menu Options</h3>
+                <p className="text-xs text-dark-400 mt-1">
+                  Choose what each role is shown. Unticked entries are removed from that role's side
+                  menu, top bar and Ctrl-K palette, for every account with the role, on every browser.
+                </p>
+              </div>
+              <div className="flex items-center gap-2 shrink-0">
+                {menuSaving && <span className="text-xs text-dark-400">Saving…</span>}
+                <label htmlFor="menu_role" className="text-xs text-dark-300">Role</label>
+                <select
+                  id="menu_role"
+                  value={menuRole}
+                  onChange={e => setMenuRole(e.target.value as ConfigurableRole)}
+                  className="px-2 py-1.5 rounded-lg bg-dark-900 border border-dark-500 text-sm text-dark-100 outline-none focus:ring-2 focus:ring-accent-500 capitalize"
+                >
+                  {CONFIGURABLE_ROLES.map(r => (
+                    <option key={r} value={r}>{r}</option>
+                  ))}
+                </select>
+              </div>
+            </div>
+            {/* The admin row is a default, not a decision, and the difference
+                has to be visible at the moment of ticking — otherwise an admin
+                sets "the admin menu" and cannot explain why their colleague's
+                is different. */}
+            {menuRole === "admin" && (
+              <div className="mt-3 flex items-center gap-4 flex-wrap">
+                <div className="flex items-center gap-1 bg-dark-900 border border-dark-600 rounded-lg p-0.5">
+                  {([
+                    { id: "default" as const, label: "Default for admins" },
+                    { id: "mine" as const, label: "Just me, this browser" },
+                  ]).map(s => (
+                    <button
+                      key={s.id}
+                      onClick={() => setAdminScope(s.id)}
+                      className={`px-2.5 py-1 text-xs rounded-md transition-colors ${
+                        adminScope === s.id ? "bg-dark-700 text-dark-50" : "text-dark-400 hover:text-dark-200"
+                      }`}
+                    >
+                      {s.label}
+                    </button>
+                  ))}
+                </div>
+                {adminScope === "mine" && readAdminOverride() !== null && (
+                  <button
+                    onClick={() => { writeAdminOverride(null); setOverrideTick(t => t + 1); }}
+                    className="px-3 py-1.5 bg-dark-700 text-dark-200 hover:bg-dark-600 border border-dark-500 rounded-lg text-xs transition-colors"
+                  >
+                    Follow the default again
+                  </button>
+                )}
+                <p className="text-xs text-dark-400">
+                  {adminScope === "mine"
+                    ? "Applies to your browser only. Any admin can do this, so nobody can be locked out of a menu."
+                    : "The starting point for every admin who has not set their own."}
+                </p>
+              </div>
+            )}
+
+            {/* Said here rather than only in a commit message. An operator
+                reaching for this to stop a role doing something needs to be
+                told, at the moment they reach for it, that it will not. */}
+            <p className="text-xs text-warn-400/90 mt-3">
+              This changes what is <strong>shown</strong>, not what is <strong>allowed</strong>. A
+              hidden page still opens from its URL, and still applies the access rules it always
+              did — use roles, not this, to restrict what someone can do.
+            </p>
+          </div>
+          <div className="p-5 space-y-6">
+            {toggleableNavGroups().map(group => (
+              <div key={group.key}>
+                <h4 className="text-[11px] font-medium text-dark-400 uppercase font-mono tracking-widest mb-2">{group.label}</h4>
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-6 gap-y-2">
+                  {group.items.map(item => (
+                    <label key={item.to} className="flex items-center gap-2 text-sm text-dark-100 cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={!menuEditingSet().has(item.to)}
+                        onChange={e => setMenuEntryShown(item.to, e.target.checked)}
+                        className="rounded border-dark-500 text-rust-500 focus:ring-accent-500"
+                      />
+                      {item.label}
+                    </label>
+                  ))}
+                </div>
+              </div>
+            ))}
+
+            <div>
+              <h4 className="text-[11px] font-medium text-dark-400 uppercase font-mono tracking-widest mb-2">Top Bar</h4>
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-6 gap-y-2">
+                {CHROME_ITEMS.map(c => (
+                  <label key={c.key} className="flex items-center gap-2 text-sm text-dark-100 cursor-pointer" title={c.hint}>
+                    <input
+                      type="checkbox"
+                      checked={!menuEditingSet().has(c.key)}
+                      onChange={e => setMenuEntryShown(c.key, e.target.checked)}
+                      className="rounded border-dark-500 text-rust-500 focus:ring-accent-500"
+                    />
+                    {c.label}
+                  </label>
+                ))}
+              </div>
+            </div>
+
+            {/* Shown, disabled, and ticked — rather than left out of the list.
+                An operator looking for "why can I not hide Settings" needs to
+                find the answer here; an absent row answers nothing. */}
+            <div>
+              <h4 className="text-[11px] font-medium text-dark-400 uppercase font-mono tracking-widest mb-2">Always shown</h4>
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-6 gap-y-2">
+                {[
+                  { label: "Dashboard", why: "Where every layout's logo links, and where a page you cannot reach sends you back to." },
+                  { label: "Settings", why: "The only way back to these checkboxes." },
+                  { label: "My Account", why: "The one entry every role can see — password, 2FA, passkeys and sessions live behind it." },
+                  { label: "Signed-in user and Logout", why: "You must always be able to see who you are signed in as, and sign out." },
+                ].map(r => (
+                  <label key={r.label} className="flex items-center gap-2 text-sm text-dark-400 cursor-not-allowed" title={r.why}>
+                    <input type="checkbox" checked disabled className="rounded border-dark-600 opacity-50" />
+                    {r.label}
+                  </label>
+                ))}
+              </div>
+            </div>
+
+            <p className="text-xs text-dark-400 border-t border-dark-600 pt-4">
+              {editingOwnAdminView
+                ? "Saved in this browser, for your account only."
+                : "Saved panel-side and applied to every account with the selected role. A signed-in account picks the change up on its next page load."}
+            </p>
           </div>
         </div>
         </>)}


### PR DESCRIPTION
## What

A **Menu Options** tab in Settings with a role selector and a checkbox per menu entry. Unticking one removes it from that role's side menu, top bar and Ctrl-K palette.

## Why

The panel does DNS, mail, Docker, git deploys, WordPress, backups, resellers and telemetry, and shows every one of those doors to an operator who uses four of them — 26 sidebar rows across five groups, with no way to put away the ones a given box will never use. It also gives an operator standing a box up for a client no way to make that client's menu right before they first sign in.

## Model

The hidden set is stored panel-side as `menu_hidden_{role}` and applies to every account with that role, on every browser.

**The admin row is a default rather than a decision, and that asymmetry is deliberate.** For `reseller`, `user` and `client` the stored array is what the role sees. For `admin` it is the starting point, and any administrator may override it for their own browser — an operator debugging a box has to be able to get every door back without another account's help, and there is nobody above an admin to restore a row they can no longer find. The scope control on the tab says which of the two is being edited.

**This is presentation, not permission**, and the tab says so where the ticking happens rather than only in a commit message. A hidden row's route still resolves and every page still applies the access rules it always did. The hidden set is kept out of `isNavVisible`, which answers the different question of whether an account may be *offered* a page — folding them together would make a checkbox in Settings look like a security control, and would invite someone to hide a row instead of restricting it.

Four entries can never be hidden, and are listed in the tab as ticked-and-disabled rather than omitted so an operator can see why: Dashboard (where every layout's logo links), Settings (the only way back to these checkboxes), My Account (the sole entry every role can see) and the signed-in user with its Logout button.

## New endpoint

`GET /api/settings` is `AdminUser`, so the accounts this shapes are exactly the ones that cannot read it. `GET /api/menu-options` answers only for `claims.role`, the way `branding` already does for a single other key, and returns the role alongside the set — the caller has to know whether what it received is binding or a default, and deriving that separately in the frontend is how the two would drift.

## Notes for review

- The checkbox list is **derived from `navGroups`**, not restated, so a row added to the registry gets a checkbox with no second list to update. A hardcoded copy is how the command palette came to offer pages the sidebar did not.
- Top-bar controls have no registry of their own, so they are enumerated in `menuOptions.ts` and keyed `chrome:*` to keep one flat array free of collisions with paths. The bell and the `/notifications` nav row are separate checkboxes.
- The dashboard's **"+ Deploy App"** and **"+ Add Site"** are gated on the same checkboxes as the Docker Apps and Sites rows — leaving a shortcut there would put the hidden thing back on the first screen the account sees.
- A malformed `menu_hidden_*` is rejected on save. All three readers (backend, checkboxes, layouts) treat an unparseable value as "hide nothing", so a bad array would otherwise fail silently on somebody else's screen.
- The Ctrl-K palette honours the hidden set. Happy to back that out if you would rather it stay a full escape hatch — it is one condition in `CommandPalette.tsx`.

## New env vars / migrations / dependencies

None. Four new `ALLOWED_KEYS` entries (`menu_hidden_admin|reseller|user|client`), one new route, no new crates or packages, no migration — the `settings` table already holds arbitrary keys.

## Testing

- `tests/settings-controls-pin-e2e.sh`: **19 passed, 0 failed** with the four new keys. §1 credits them through the `format!("menu_hidden_{` prefix and §9 through the `menu_hidden_${menuRole}` template in `Settings.tsx`, so neither arm needed an exemption. Worth knowing §9 scans `.tsx` only, which is why that template has to stay there.
- Backend `cargo test`: 487 passed, 0 failed. No new `clippy` findings; new lines are `rustfmt`-clean. I did not run `cargo fmt` across the crate, as the tree has pre-existing drift that would bury the change.
- Frontend `tsc -b` and `npm run build`: clean.
- **Verified in a running panel**, not only compiled: hiding a row drops it from the sidebar live and from the Ctrl-K palette; the setting persists to the `settings` table and survives a reload; "+ Deploy App" disappears with the Docker Apps row while "+ Add Site" stays; the top-bar bell and the Notifications nav row toggle independently; the always-shown four render disabled; re-ticking restores everything; and an admin's own override writes `localStorage` while leaving the stored default untouched.

## Size

10 files, +633 / −23, one commit.

I did not add a `FEATURES.md` row — happy to if you would like it recorded; it did not obviously fit the existing table shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
